### PR TITLE
Some minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINDIR = bin
 VPATH = src
 BINS = $(addprefix $(BINDIR)/, hello-world.bin characterset.bin )
-ASM = asm6809.exe --dragondos
+ASM = asm6809 --dragondos
 
 $(BINDIR)/%.bin : %.asm
 	$(ASM) --output $@ $<

--- a/src/hello-world.asm
+++ b/src/hello-world.asm
@@ -21,7 +21,7 @@
 	leax	text,pcr
 loop	lda	,x+
 	beq	end
-	jsr	OUTCH
+	jsr	OUTCHAR
 	bra	loop
 end	rts
 


### PR DESCRIPTION
- Fix build on Linux by removing the .exe suffix on referenced executables.
- Fix an invalid symbol reference (typo?)